### PR TITLE
fix: restore default-connection auth env after same-provider OAuth setup (#546)

### DIFF
--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -281,6 +281,13 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
       // Reinitialize auth for the connection that was just created/updated,
       // not the global default (which may be a different connection).
       await sessionManager.reinitializeAuth(setup.slug)
+      // Restore process env to the configured default when setup slug differs.
+      // Otherwise OAuth/API key env can leak to subsequent sessions (#546).
+      const defaultSlug = getDefaultLlmConnection()
+      if (defaultSlug && defaultSlug !== setup.slug) {
+        await sessionManager.reinitializeAuth(defaultSlug)
+        deps.platform.logger?.info(`Restored auth env to default connection: ${defaultSlug}`)
+      }
       deps.platform.logger?.info('Reinitialized auth after LLM connection setup')
 
       // Clear "Setup later" flag now that user has configured a provider


### PR DESCRIPTION
## Summary

Restore process env to the user's configured `defaultLlmConnection` after setting up a new LLM connection that is not the default. Without this, `process.env.CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) leaks into subsequent sessions that were supposed to use a different connection, burning quota on the wrong account.

## Why this matters

From #546 (@boykioyb, version 0.8.9):

> When a user has multiple `llmConnections` entries with the same `providerType: "anthropic"` and `authType: "oauth"` (e.g. three separate Claude Max OAuth accounts), Craft Agents silently routes API calls through the connection with the most recent `lastUsedAt` timestamp rather than the one set as `defaultLlmConnection`. This causes the wrong Anthropic account's quota to be consumed.

The reporter's hypothesis was lastUsedAt-based selection, but the actual resolution logic (`resolveSessionConnection`, `resolveBackendContext`) already looks up by slug first. The real root cause is process-env pollution in the setup-time RPC handler.

## Root cause

`packages/server-core/src/handlers/rpc/llm-connections.ts:283` intentionally calls:

```ts
await sessionManager.reinitializeAuth(setup.slug)
```

after a new connection finishes setup. This is there so the Claude SDK can immediately test the new credentials. But `reinitializeAuth(slug)` (in `SessionManager.ts:1506`) writes the slug's token into `process.env.CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`), which is process-global.

If `setup.slug` is not the configured default, process env now points at the newly-added connection. Subsequent sessions inherit it via `process.env` until `ClaudeAgent.postInit()` runs for a different session. For sessions that reuse an already-spawned Claude SDK subprocess, or for any API path reading `process.env` directly, the wrong token wins.

This matches the reporter's evidence: after OAuth-ing `claude-max-3` last, env holds its token, so the next session (which should use the default `claude-max`) consumes `claude-max-3`'s quota.

## Changes

`packages/server-core/src/handlers/rpc/llm-connections.ts`:

Added a 5-line restore block right after the existing setup-time `reinitializeAuth(setup.slug)`. When the new connection is not the default, it calls `reinitializeAuth(defaultSlug)` to reset process env back to the user's configured default:

```ts
await sessionManager.reinitializeAuth(setup.slug)
// Restore process env to the configured default when setup slug differs.
// Otherwise OAuth/API key env can leak to subsequent sessions (#546).
const defaultSlug = getDefaultLlmConnection()
if (defaultSlug && defaultSlug !== setup.slug) {
  await sessionManager.reinitializeAuth(defaultSlug)
  deps.platform.logger?.info(`Restored auth env to default connection: ${defaultSlug}`)
}
```

`getDefaultLlmConnection` is already imported at the top of the file.

## Scope

- Does not change `SessionManager.reinitializeAuth`.
- Does not change `resolveSessionConnection` or `resolveBackendContext`.
- Does not change when connections become the default (still only on first setup).
- Only affects the post-setup RPC handler path.

## Testing

I could not validate this against a multi-account Claude Max setup (do not have three OAuth'd accounts). The fix is reasoned from code reading:

1. `bun run typecheck:all` covers `packages/server-core` via its own tsc run. Local `cd packages/server-core && tsc --noEmit` passes.
2. `bun run test:shared:llm-connections` passes (14/14 tests) - unaffected by this change, but ran for baseline.
3. Shared config tests still pass.

Would appreciate if @boykioyb can validate on their three-account setup before merge.

Fixes #546

