### PR TITLE
Rebuild + reinstall Craft Agents Mac app to pick up the ⌘K palette fix (Model group now lists Opus 5 from the live connection list).

### DIFF
--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -76,6 +76,10 @@ import { useLinkInterceptor, type FilePreviewState } from '@/hooks/useLinkInterc
 import { useTransportConnectionState } from '@/hooks/useTransportConnectionState'
 import { useStaleSessionRecovery } from '@/hooks/useStaleSessionRecovery'
 import { TransportConnectionBanner, shouldShowTransportConnectionBanner } from '@/components/app-shell/TransportConnectionBanner'
+import {
+  markBackgroundTaskSignal,
+  markLiveBackgroundTasksOrphaned,
+} from '@/components/app-shell/background-task-chip-state'
 import { getFileManagerName } from '@/lib/platform'
 import { rendererLog } from '@/lib/logger'
 import { ActionRegistryProvider } from '@/actions'
@@ -133,14 +137,16 @@ function handleBackgroundTaskEvent(
     const exists = currentTasks.some(t => t.toolUseId === evt.toolUseId)
     if (!exists) {
       const isWorkflow = evt.kind === 'workflow'
+      const startTime = Date.now()
       store.set(backgroundTasksAtom, [
         ...currentTasks,
         {
           id: evt.taskId as string,
           type: isWorkflow ? ('workflow' as const) : ('agent' as const),
           toolUseId: evt.toolUseId as string,
-          startTime: Date.now(),
+          startTime,
           elapsedSeconds: 0,
+          lastSignalAt: startTime,
           intent: evt.intent as string | undefined,
           status: 'running' as const,
           ...(isWorkflow ? { workflowId: evt.workflowId as string | undefined, agentsCompleted: 0 } : {}),
@@ -148,25 +154,29 @@ function handleBackgroundTaskEvent(
       ])
     }
   } else if (event.type === 'workflow_agent_completed' && 'workflowId' in evt) {
-    // One sub-agent of a running Workflow finished — bump the owning chip's count.
+    // One sub-agent of a running Workflow finished — bump the owning chip's count
+    // and treat it as evidence that a stale workflow is still alive.
     const currentTasks = store.get(backgroundTasksAtom)
+    const now = Date.now()
     store.set(backgroundTasksAtom, currentTasks.map(t =>
       t.type === 'workflow' && t.workflowId === evt.workflowId
-        ? { ...t, agentsCompleted: (t.agentsCompleted ?? 0) + 1 }
+        ? { ...markBackgroundTaskSignal(t, now), agentsCompleted: (t.agentsCompleted ?? 0) + 1 }
         : t
     ))
   } else if (event.type === 'shell_backgrounded' && 'shellId' in evt && 'toolUseId' in evt) {
     const currentTasks = store.get(backgroundTasksAtom)
     const exists = currentTasks.some(t => t.toolUseId === evt.toolUseId)
     if (!exists) {
+      const startTime = Date.now()
       store.set(backgroundTasksAtom, [
         ...currentTasks,
         {
           id: evt.shellId as string,
           type: 'shell' as const,
           toolUseId: evt.toolUseId as string,
-          startTime: Date.now(),
+          startTime,
           elapsedSeconds: 0,
+          lastSignalAt: startTime,
           intent: evt.intent as string | undefined,
           status: 'running' as const,
         },
@@ -174,9 +184,10 @@ function handleBackgroundTaskEvent(
     }
   } else if (event.type === 'task_progress' && 'toolUseId' in evt && 'elapsedSeconds' in evt) {
     const currentTasks = store.get(backgroundTasksAtom)
+    const now = Date.now()
     store.set(backgroundTasksAtom, currentTasks.map(t =>
       t.toolUseId === evt.toolUseId
-        ? { ...t, elapsedSeconds: evt.elapsedSeconds as number }
+        ? { ...markBackgroundTaskSignal(t, now), elapsedSeconds: evt.elapsedSeconds as number }
         : t
     ))
   } else if (event.type === 'task_completed' && 'taskId' in evt) {
@@ -220,27 +231,17 @@ function handleBackgroundTaskEvent(
       store.set(backgroundTasksAtom, currentTasks.filter(t => t.toolUseId !== evt.toolUseId))
     }
   } else if (event.type === 'complete' || event.type === 'interrupted' || event.type === 'error') {
-    // Orphan backstop: when the turn ends, any chip still marked 'running' belongs
-    // to a background sub-agent whose per-turn subprocess is being torn down — with
-    // the default (keep-alive OFF) model it has almost certainly died. Flip it to
-    // 'orphaned' (visually distinct, auto-expires) so the bar never shows a false
-    // "running" forever. This is the reliability fix that lets the bar be re-enabled.
-    //
-    // WS2 keep-alive: when the main process reports `backgroundTasksAlive` on the
-    // complete event, the persistent query stays open across turns and the tasks
-    // genuinely survive — so do NOT orphan them here. They stay 'running' until a
-    // real `task_completed` arrives (routed via the between-turns background sink).
-    // Without this guard the chip lies "orphaned" while the agent is still working.
+    // Orphan backstop: without keep-alive, turn teardown is authoritative evidence
+    // that both running and uncertain/stale background tasks died with the SDK
+    // subprocess. With keep-alive they may genuinely survive, so preserve them for
+    // a later progress or task_completed signal.
     if (evt.backgroundTasksAlive === true) {
       return
     }
     const currentTasks = store.get(backgroundTasksAtom)
-    if (currentTasks.some(t => t.status === 'running')) {
-      store.set(backgroundTasksAtom, currentTasks.map(t =>
-        t.status === 'running'
-          ? { ...t, status: 'orphaned' as const, completedAt: Date.now() }
-          : t
-      ))
+    const nextTasks = markLiveBackgroundTasksOrphaned(currentTasks, Date.now())
+    if (nextTasks !== currentTasks) {
+      store.set(backgroundTasksAtom, nextTasks)
     }
   }
 }

--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -2053,6 +2053,8 @@ export default function App() {
         currentThinkingLevel={sessionSelection.selected ? sessionOptions.get(sessionSelection.selected)?.thinkingLevel : undefined}
         onThinkingLevelChange={(level) => sessionSelection.selected && handleSessionOptionsChange(sessionSelection.selected, { thinkingLevel: level })}
         onModelChange={(model, connection) => sessionSelection.selected && windowWorkspaceId && window.electronAPI.setSessionModel(sessionSelection.selected, windowWorkspaceId, model, connection)}
+        llmConnections={llmConnections}
+        workspaceDefaultConnectionSlug={defaultLlmConnectionSlug}
       />
       <FocusProvider>
         <DismissibleLayerProvider>

--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -79,6 +79,7 @@ import { TransportConnectionBanner, shouldShowTransportConnectionBanner } from '
 import { getFileManagerName } from '@/lib/platform'
 import { rendererLog } from '@/lib/logger'
 import { ActionRegistryProvider } from '@/actions'
+import { CommandPaletteHost } from '@/components/app-shell/CommandPaletteHost'
 import { toast } from 'sonner'
 
 type AppState = 'loading' | 'onboarding' | 'reauth' | 'workspace-picker' | 'ready'
@@ -2042,6 +2043,16 @@ export default function App() {
     <PlatformProvider actions={platformActions}>
     <ShikiThemeProvider shikiTheme={shikiTheme}>
       <ActionRegistryProvider>
+      <CommandPaletteHost
+        activeSessionId={sessionSelection.selected}
+        workspaceId={windowWorkspaceId}
+        onSetStatus={handleSessionStatusChange}
+        onArchive={handleArchiveSession}
+        onUnarchive={handleUnarchiveSession}
+        currentThinkingLevel={sessionSelection.selected ? sessionOptions.get(sessionSelection.selected)?.thinkingLevel : undefined}
+        onThinkingLevelChange={(level) => sessionSelection.selected && handleSessionOptionsChange(sessionSelection.selected, { thinkingLevel: level })}
+        onModelChange={(model, connection) => sessionSelection.selected && windowWorkspaceId && window.electronAPI.setSessionModel(sessionSelection.selected, windowWorkspaceId, model, connection)}
+      />
       <FocusProvider>
         <DismissibleLayerProvider>
         <ModalProvider>

--- a/apps/electron/src/renderer/actions/definitions.ts
+++ b/apps/electron/src/renderer/actions/definitions.ts
@@ -11,6 +11,13 @@ export const actions = {
     defaultHotkey: 'mod+n',
     category: 'General',
   },
+  'app.commandPalette': {
+    id: 'app.commandPalette',
+    label: 'Command Palette',
+    description: 'Search and run any command',
+    defaultHotkey: 'mod+k',
+    category: 'General',
+  },
   'app.newChatInPanel': {
     id: 'app.newChatInPanel',
     label: 'New Chat in Panel',

--- a/apps/electron/src/renderer/atoms/background-finished.ts
+++ b/apps/electron/src/renderer/atoms/background-finished.ts
@@ -21,10 +21,10 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
-/** Whether the in-app "background session finished" chip is shown. Default on. */
+/** Whether the in-app "background session finished" chip is shown. Default off. */
 export const showBackgroundFinishedChipAtom = atomWithStorage<boolean>(
   'craft-show-background-finished-chip',
-  true
+  false
 )
 
 export interface BackgroundFinishedEntry {

--- a/apps/electron/src/renderer/atoms/sessions.ts
+++ b/apps/electron/src/renderer/atoms/sessions.ts
@@ -699,12 +699,14 @@ export const forceSessionMessagesReloadAtom = atom(
 /**
  * Lifecycle status of a background task chip.
  * - `running`  — backgrounded, no terminal signal yet (chip shows a spinner + live elapsed).
+ * - `stale` — no lifecycle signal arrived within the renderer timeout. The task may
+ *   still be running, so the chip shows an unknown state and remains recoverable.
  * - `completed`/`failed`/`stopped` — a real task_completed notification arrived.
  * - `orphaned` — the turn that owned the task ended before it finished, so it was
  *   terminated with that turn's subprocess. Shown distinctly instead of a false
  *   "running". Not produced once WS2 keep-alive is enabled.
  */
-export type BackgroundTaskStatus = 'running' | 'completed' | 'failed' | 'stopped' | 'orphaned'
+export type BackgroundTaskStatus = 'running' | 'stale' | 'completed' | 'failed' | 'stopped' | 'orphaned'
 
 export interface BackgroundTask {
   /** Task or shell ID */
@@ -721,6 +723,8 @@ export interface BackgroundTask {
   startTime: number
   /** Elapsed seconds (from progress events; the chip also derives it from startTime) */
   elapsedSeconds: number
+  /** Last renderer-observed lifecycle/progress signal; falls back to startTime. */
+  lastSignalAt?: number
   /** Task intent/description */
   intent?: string
   /** Lifecycle status; defaults to 'running' when added */

--- a/apps/electron/src/renderer/components/app-shell/ActiveTasksBar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ActiveTasksBar.tsx
@@ -8,20 +8,12 @@
 import React from 'react'
 import { useSetAtom } from 'jotai'
 import { TaskActionMenu, type TerminalOverlayData } from './TaskActionMenu'
+import { advanceBackgroundTaskChips } from './background-task-chip-state'
 import { backgroundTasksAtomFamily, type BackgroundTask } from '@/atoms/sessions'
 
 // Re-exported for existing consumers (ActiveOptionBadges, ChatInputZone, TaskActionMenu)
 // so the single definition lives in atoms/sessions.ts.
 export type { BackgroundTask } from '@/atoms/sessions'
-
-/**
- * How long a terminal/orphaned chip lingers before it is auto-pruned. Terminal
- * (completed/failed/stopped) chips clear quickly so the bar reflects live work;
- * orphaned chips linger a bit longer so the user actually notices that a task
- * died at turn end rather than silently vanishing.
- */
-const TERMINAL_LINGER_MS = 8_000
-const ORPHANED_LINGER_MS = 20_000
 
 export interface ActiveTasksBarProps {
   /** Active background tasks */
@@ -46,23 +38,12 @@ export interface ActiveTasksBarProps {
 export function ActiveTasksBar({ tasks, sessionId, onKillTask, onInsertMessage, onShowTerminalOverlay, className }: ActiveTasksBarProps) {
   const setTasks = useSetAtom(backgroundTasksAtomFamily(sessionId))
 
-  // Auto-expiry ticker: prune terminal/orphaned chips after their linger window
-  // so the bar reflects live work and terminal chips don't accumulate. Running
-  // chips are never pruned here — they clear on task_completed or are flipped to
-  // 'orphaned' at turn end (App.tsx handleBackgroundTaskEvent). This is the
-  // reliability backstop that was missing when the bar was first disabled.
+  // Stop an unconfirmed chip from spinning forever without pretending the task
+  // died. Old no-signal tasks become `stale` and remain recoverable; only real
+  // terminal/orphaned states are auto-pruned by the pure lifecycle helper.
   React.useEffect(() => {
     const interval = setInterval(() => {
-      const now = Date.now()
-      setTasks((prev) => {
-        const next = prev.filter((t) => {
-          if (t.status === 'running') return true
-          const age = now - (t.completedAt ?? now)
-          const linger = t.status === 'orphaned' ? ORPHANED_LINGER_MS : TERMINAL_LINGER_MS
-          return age < linger
-        })
-        return next.length === prev.length ? prev : next
-      })
+      setTasks((prev) => advanceBackgroundTaskChips(prev, Date.now()))
     }, 1000)
     return () => clearInterval(interval)
   }, [sessionId, setTasks])

--- a/apps/electron/src/renderer/components/app-shell/CommandPaletteHost.tsx
+++ b/apps/electron/src/renderer/components/app-shell/CommandPaletteHost.tsx
@@ -21,6 +21,10 @@ import {
 import { useStatuses } from '@/hooks/useStatuses'
 import { sessionMetaMapAtom } from '@/atoms/sessions'
 import { ANTHROPIC_MODELS, getModelDisplayName } from '@config/models'
+import {
+  resolveEffectiveConnectionSlug,
+  type LlmConnectionWithStatus,
+} from '@config/llm-connections'
 import { THINKING_LEVELS, type ThinkingLevel } from '@craft-agent/shared/agent/thinking-levels'
 import { cn } from '@/lib/utils'
 
@@ -44,6 +48,10 @@ export interface CommandPaletteHostProps {
   onThinkingLevelChange?: (level: ThinkingLevel) => void
   /** Change the active session's model. */
   onModelChange?: (model: string, connection?: string) => void
+  /** LLM connections (their live model lists drive the Model group). */
+  llmConnections?: LlmConnectionWithStatus[]
+  /** Workspace default connection slug (for resolving the effective connection). */
+  workspaceDefaultConnectionSlug?: string | null
 }
 
 /**
@@ -65,6 +73,8 @@ export function CommandPaletteHost({
   currentThinkingLevel,
   onThinkingLevelChange,
   onModelChange,
+  llmConnections = [],
+  workspaceDefaultConnectionSlug,
 }: CommandPaletteHostProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
@@ -80,6 +90,22 @@ export function CommandPaletteHost({
   const isArchived = Boolean(activeMeta?.isArchived)
   const currentModel = activeMeta?.model
   const currentConnection = activeMeta?.llmConnection
+
+  // Mirror CompactModelSelector: use the active connection's live model list
+  // (this is where newer models like Opus 5 appear), falling back to the
+  // static Anthropic registry when a connection exposes no list.
+  const effectiveConnectionSlug = resolveEffectiveConnectionSlug(
+    currentConnection,
+    workspaceDefaultConnectionSlug ?? undefined,
+    llmConnections,
+  )
+  const effectiveConnection = effectiveConnectionSlug
+    ? llmConnections.find((c) => c.slug === effectiveConnectionSlug) ?? null
+    : null
+  const availableModels = effectiveConnection?.models ?? ANTHROPIC_MODELS
+  // Entries may be full ModelDefinition objects or bare id strings.
+  const modelIdOf = (m: (typeof availableModels)[number]) =>
+    typeof m === 'string' ? m : m.id
 
   const runAction = (id: ActionId) => {
     setOpen(false)
@@ -180,15 +206,16 @@ export function CommandPaletteHost({
 
             {activeSessionId && onModelChange && (
               <CommandGroup heading={t('commandPalette.modelGroup', 'Model')}>
-                {ANTHROPIC_MODELS.map((m) => {
-                  const isCurrent = m.id === currentModel
+                {availableModels.map((m) => {
+                  const modelId = modelIdOf(m)
+                  const isCurrent = modelId === currentModel
                   return (
                     <CommandItem
-                      key={`model-${m.id}`}
-                      value={`model ${m.name} ${m.shortName} ${m.id}`}
-                      onSelect={() => runSetModel(m.id)}
+                      key={`model-${modelId}`}
+                      value={`model ${getModelDisplayName(modelId)} ${modelId}`}
+                      onSelect={() => runSetModel(modelId)}
                     >
-                      <span>{getModelDisplayName(m.id)}</span>
+                      <span>{getModelDisplayName(modelId)}</span>
                       {isCurrent && <Check className="ml-auto opacity-60" />}
                     </CommandItem>
                   )

--- a/apps/electron/src/renderer/components/app-shell/CommandPaletteHost.tsx
+++ b/apps/electron/src/renderer/components/app-shell/CommandPaletteHost.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useAtomValue } from 'jotai'
+import { Archive, ArchiveRestore, Check } from 'lucide-react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+} from '@/components/ui/command'
+import {
+  useAction,
+  useActionRegistry,
+  actionsByCategory,
+  type ActionId,
+} from '@/actions'
+import { useStatuses } from '@/hooks/useStatuses'
+import { sessionMetaMapAtom } from '@/atoms/sessions'
+import { ANTHROPIC_MODELS, getModelDisplayName } from '@config/models'
+import { THINKING_LEVELS, type ThinkingLevel } from '@craft-agent/shared/agent/thinking-levels'
+import { cn } from '@/lib/utils'
+
+// Default statuses ship translations under status.<id>; custom ones use their label.
+const DEFAULT_STATUS_IDS = new Set(['backlog', 'todo', 'needs-review', 'done', 'cancelled'])
+
+export interface CommandPaletteHostProps {
+  /** The session the user is currently viewing (status/archive commands target it). */
+  activeSessionId?: string | null
+  /** Workspace whose statuses populate the session commands. */
+  workspaceId?: string | null
+  /** Change the active session's status (status id string). */
+  onSetStatus?: (sessionId: string, statusId: string) => void
+  /** Archive the active session. */
+  onArchive?: (sessionId: string) => void
+  /** Unarchive the active session. */
+  onUnarchive?: (sessionId: string) => void
+  /** Current session reasoning depth (for the checkmark). */
+  currentThinkingLevel?: ThinkingLevel
+  /** Change the active session's reasoning depth. */
+  onThinkingLevelChange?: (level: ThinkingLevel) => void
+  /** Change the active session's model. */
+  onModelChange?: (model: string, connection?: string) => void
+}
+
+/**
+ * Global command palette (⌘K / Ctrl+K).
+ *
+ * Self-contained: owns its open state, registers the `app.commandPalette`
+ * action (fired by the registry's global keydown dispatcher on mod+k), and
+ * runs actions through the registry. When a session is active it also exposes
+ * status + archive commands for that session.
+ *
+ * Mount once, as a descendant of <ActionRegistryProvider>.
+ */
+export function CommandPaletteHost({
+  activeSessionId,
+  workspaceId,
+  onSetStatus,
+  onArchive,
+  onUnarchive,
+  currentThinkingLevel,
+  onThinkingLevelChange,
+  onModelChange,
+}: CommandPaletteHostProps) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const { execute, getHotkeyDisplay } = useActionRegistry()
+  const { statuses } = useStatuses(workspaceId ?? null)
+  const metaMap = useAtomValue(sessionMetaMapAtom)
+
+  // mod+k toggles the palette (handler invoked by the global hotkey dispatcher)
+  useAction('app.commandPalette', () => setOpen((v) => !v))
+
+  const activeMeta = activeSessionId ? metaMap.get(activeSessionId) : undefined
+  const currentStatusId = activeMeta?.sessionStatus || 'todo'
+  const isArchived = Boolean(activeMeta?.isArchived)
+  const currentModel = activeMeta?.model
+  const currentConnection = activeMeta?.llmConnection
+
+  const runAction = (id: ActionId) => {
+    setOpen(false)
+    execute(id)
+  }
+
+  const runSetStatus = (statusId: string) => {
+    setOpen(false)
+    if (activeSessionId && statusId !== currentStatusId) {
+      onSetStatus?.(activeSessionId, statusId)
+    }
+  }
+
+  const runArchiveToggle = () => {
+    setOpen(false)
+    if (!activeSessionId) return
+    if (isArchived) onUnarchive?.(activeSessionId)
+    else onArchive?.(activeSessionId)
+  }
+
+  const runSetThinkingLevel = (level: ThinkingLevel) => {
+    setOpen(false)
+    if (activeSessionId && level !== currentThinkingLevel) onThinkingLevelChange?.(level)
+  }
+
+  const runSetModel = (modelId: string) => {
+    setOpen(false)
+    if (activeSessionId && modelId !== currentModel) onModelChange?.(modelId, currentConnection)
+  }
+
+  const statusLabel = (id: string, label: string) =>
+    DEFAULT_STATUS_IDS.has(id) ? t(`status.${id}`, label) : label
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        showCloseButton={false}
+        className={cn(
+          'overflow-hidden p-0 border-border/50',
+          // glassy: translucent surface + blur so the app shows through
+          'bg-background/70 backdrop-blur-2xl shadow-2xl',
+          'supports-[backdrop-filter]:bg-background/60',
+        )}
+      >
+        <DialogTitle className="sr-only">
+          {t('commandPalette.title', 'Command palette')}
+        </DialogTitle>
+        <Command
+          className={cn(
+            'bg-transparent',
+            '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+            '[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2',
+            '[&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5',
+            '[&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3',
+            '[&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5',
+            // glassy hover/selection on items
+            '[&_[cmdk-item][data-selected=true]]:bg-foreground/10 [&_[cmdk-item][data-selected=true]]:backdrop-blur-sm',
+          )}
+        >
+          <CommandInput
+            placeholder={t('commandPalette.placeholder', 'Type a command or search...')}
+          />
+          <CommandList>
+            <CommandEmpty>{t('commandPalette.empty', 'No results found.')}</CommandEmpty>
+
+            {activeSessionId && (
+              <CommandGroup heading={t('commandPalette.sessionGroup', 'Session')}>
+                {statuses.map((s) => {
+                  const isCurrent = s.id === currentStatusId
+                  return (
+                    <CommandItem
+                      key={`status-${s.id}`}
+                      value={`set status ${s.label} ${s.id}`}
+                      onSelect={() => runSetStatus(s.id)}
+                    >
+                      <span>
+                        {t('commandPalette.setStatus', 'Set status:')}{' '}
+                        {statusLabel(s.id, s.label)}
+                      </span>
+                      {isCurrent && <Check className="ml-auto opacity-60" />}
+                    </CommandItem>
+                  )
+                })}
+                <CommandItem
+                  key="archive-toggle"
+                  value={isArchived ? 'unarchive session restore' : 'archive session'}
+                  onSelect={runArchiveToggle}
+                >
+                  {isArchived ? <ArchiveRestore /> : <Archive />}
+                  <span>
+                    {isArchived
+                      ? t('commandPalette.unarchive', 'Unarchive session')
+                      : t('commandPalette.archive', 'Archive session')}
+                  </span>
+                </CommandItem>
+              </CommandGroup>
+            )}
+
+            {activeSessionId && onModelChange && (
+              <CommandGroup heading={t('commandPalette.modelGroup', 'Model')}>
+                {ANTHROPIC_MODELS.map((m) => {
+                  const isCurrent = m.id === currentModel
+                  return (
+                    <CommandItem
+                      key={`model-${m.id}`}
+                      value={`model ${m.name} ${m.shortName} ${m.id}`}
+                      onSelect={() => runSetModel(m.id)}
+                    >
+                      <span>{getModelDisplayName(m.id)}</span>
+                      {isCurrent && <Check className="ml-auto opacity-60" />}
+                    </CommandItem>
+                  )
+                })}
+              </CommandGroup>
+            )}
+
+            {activeSessionId && onThinkingLevelChange && (
+              <CommandGroup heading={t('commandPalette.reasoningGroup', 'Reasoning depth')}>
+                {THINKING_LEVELS.map((level) => {
+                  const isCurrent = level.id === currentThinkingLevel
+                  return (
+                    <CommandItem
+                      key={`thinking-${level.id}`}
+                      value={`reasoning thinking ${level.id} ${t(level.nameKey, level.id)}`}
+                      onSelect={() => runSetThinkingLevel(level.id)}
+                    >
+                      <span>{t(level.nameKey, level.id)}</span>
+                      {isCurrent && <Check className="ml-auto opacity-60" />}
+                    </CommandItem>
+                  )
+                })}
+              </CommandGroup>
+            )}
+
+            {Object.entries(actionsByCategory).map(([category, list]) => (
+              <CommandGroup key={category} heading={category}>
+                {list
+                  .filter((a) => a.id !== 'app.commandPalette')
+                  .map((a) => {
+                    const shortcut = getHotkeyDisplay(a.id as ActionId)
+                    return (
+                      <CommandItem
+                        key={a.id}
+                        value={`${a.label} ${a.description ?? ''}`}
+                        onSelect={() => runAction(a.id as ActionId)}
+                      >
+                        <span>{a.label}</span>
+                        {shortcut && <CommandShortcut>{shortcut}</CommandShortcut>}
+                      </CommandItem>
+                    )
+                  })}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/electron/src/renderer/components/app-shell/TaskActionMenu.tsx
+++ b/apps/electron/src/renderer/components/app-shell/TaskActionMenu.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from "react-i18next"
-import { ChevronDown, Square, ArrowUpRight, CheckCircle2, XCircle, AlertTriangle } from 'lucide-react'
+import { useSetAtom } from 'jotai'
+import { ChevronDown, Square, ArrowUpRight, CheckCircle2, XCircle, AlertTriangle, X } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -12,6 +13,7 @@ import { Spinner } from '@craft-agent/ui'
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import type { BackgroundTask } from './ActiveTasksBar'
+import { backgroundTasksAtomFamily } from '@/atoms/sessions'
 
 /** Terminal data for overlay display */
 export interface TerminalOverlayData {
@@ -59,13 +61,18 @@ export interface TaskActionMenuProps {
  *
  * Provides contextual actions for background tasks:
  * - View Output: Opens task output in terminal overlay
+ * - Dismiss: Hides the renderer-only chip without stopping the task
  * - Stop Task: Kills shell tasks (agent tasks show warning)
  */
 export function TaskActionMenu({ task, sessionId, onKillTask, onInsertMessage, onShowTerminalOverlay, className }: TaskActionMenuProps) {
   const { t } = useTranslation()
   const [open, setOpen] = React.useState(false)
+  const setTasks = useSetAtom(backgroundTasksAtomFamily(sessionId))
 
-  const isTerminal = task.status !== 'running'
+  const isTerminal = task.status === 'completed'
+    || task.status === 'failed'
+    || task.status === 'stopped'
+    || task.status === 'orphaned'
 
   // Wall-clock timer for RUNNING tasks. The async-by-default agent path emits no
   // task_progress events, so deriving elapsed from startTime (rather than relying
@@ -76,12 +83,12 @@ export function TaskActionMenu({ task, sessionId, onKillTask, onInsertMessage, o
   })
 
   React.useEffect(() => {
-    if (isTerminal) return
+    if (task.status !== 'running') return
     const interval = setInterval(() => {
       setLocalElapsed(Math.floor((Date.now() - task.startTime) / 1000))
     }, 1000)
     return () => clearInterval(interval)
-  }, [isTerminal, task.startTime])
+  }, [task.status, task.startTime])
 
   const displayElapsed = isTerminal
     ? Math.max(0, Math.floor(((task.completedAt ?? Date.now()) - task.startTime) / 1000))
@@ -122,6 +129,15 @@ export function TaskActionMenu({ task, sessionId, onKillTask, onInsertMessage, o
     setOpen(false)
   }
 
+  // Manually remove this chip from the bar. The chip is renderer-only state, so
+  // dismissing it just hides the indicator — it never kills the underlying task
+  // (shells use Stop for that). This is the escape hatch for a chip that got
+  // stuck 'running' because its task_completed was lost.
+  const handleDismiss = () => {
+    setTasks((prev) => prev.filter((t) => t.id !== task.id))
+    setOpen(false)
+  }
+
   // Status → icon + tint. Running shows the spinner; terminal/orphaned states
   // are visually distinct so a chip never falsely reads as "still running".
   const statusTint = cn(
@@ -129,7 +145,7 @@ export function TaskActionMenu({ task, sessionId, onKillTask, onInsertMessage, o
     "hover:bg-white/80 dark:hover:bg-white/15",
     "data-[state=open]:bg-white/80 dark:data-[state=open]:bg-white/15",
     task.status === 'failed' && "bg-destructive/10 hover:bg-destructive/15 dark:bg-destructive/15",
-    task.status === 'orphaned' && "bg-amber-500/10 hover:bg-amber-500/15 dark:bg-amber-500/15",
+    (task.status === 'orphaned' || task.status === 'stale') && "bg-amber-500/10 hover:bg-amber-500/15 dark:bg-amber-500/15",
   )
 
   const StatusIcon = () => {
@@ -141,6 +157,7 @@ export function TaskActionMenu({ task, sessionId, onKillTask, onInsertMessage, o
       case 'stopped':
         return <Square className="h-3 w-3 opacity-60" />
       case 'orphaned':
+      case 'stale':
         return <AlertTriangle className="h-3.5 w-3.5 text-amber-600 dark:text-amber-500" />
       default:
         return <Spinner className="text-xs" />
@@ -152,11 +169,14 @@ export function TaskActionMenu({ task, sessionId, onKillTask, onInsertMessage, o
     failed: t('chat.taskStatusFailed', 'failed'),
     stopped: t('chat.taskStatusStopped', 'stopped'),
     orphaned: t('chat.taskStatusOrphaned', 'orphaned'),
+    stale: t('common.unknown'),
   }
 
   const chipTitle = task.status === 'orphaned'
     ? t('chat.taskOrphanedHint', 'This background task was terminated when its turn ended.')
-    : t("chat.clickForTaskActions")
+    : task.status === 'stale'
+      ? t('chat.taskStaleHint')
+      : t("chat.clickForTaskActions")
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -229,6 +249,12 @@ export function TaskActionMenu({ task, sessionId, onKillTask, onInsertMessage, o
         <StyledDropdownMenuItem onClick={handleViewOutput}>
           <ArrowUpRight />
           {t('chat.viewOutput')}
+        </StyledDropdownMenuItem>
+
+        {/* Dismiss - remove the chip (renderer-only; does not kill the task) */}
+        <StyledDropdownMenuItem onClick={handleDismiss}>
+          <X />
+          {t('common.dismiss')}
         </StyledDropdownMenuItem>
 
         {/* Stop Task - Only show for shell tasks (inserts kill command into input) */}

--- a/apps/electron/src/renderer/components/app-shell/__tests__/background-task-chip-state.test.ts
+++ b/apps/electron/src/renderer/components/app-shell/__tests__/background-task-chip-state.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'bun:test'
+import type { BackgroundTask } from '@/atoms/sessions'
+import {
+  advanceBackgroundTaskChips,
+  markBackgroundTaskSignal,
+  markLiveBackgroundTasksOrphaned,
+  ORPHANED_LINGER_MS,
+  RUNNING_SIGNAL_TIMEOUT_MS,
+  TERMINAL_LINGER_MS,
+} from '../background-task-chip-state'
+
+const NOW = 1_000_000_000
+
+function task(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: 'task-1',
+    type: 'agent',
+    toolUseId: 'tool-1',
+    startTime: NOW - 1_000,
+    elapsedSeconds: 1,
+    status: 'running',
+    ...overrides,
+  }
+}
+
+describe('background task chip lifecycle', () => {
+  it('keeps a recently signaled running task unchanged', () => {
+    const tasks = [task({ lastSignalAt: NOW - RUNNING_SIGNAL_TIMEOUT_MS + 1 })]
+
+    expect(advanceBackgroundTaskChips(tasks, NOW)).toBe(tasks)
+  })
+
+  it('marks a no-signal running task stale without claiming completion', () => {
+    const [stale] = advanceBackgroundTaskChips([
+      task({ lastSignalAt: NOW - RUNNING_SIGNAL_TIMEOUT_MS }),
+    ], NOW)
+
+    expect(stale?.status).toBe('stale')
+    expect(stale?.completedAt).toBeUndefined()
+  })
+
+  it('does not auto-prune stale tasks', () => {
+    const tasks = [task({
+      status: 'stale',
+      startTime: NOW - 10 * RUNNING_SIGNAL_TIMEOUT_MS,
+      lastSignalAt: NOW - 10 * RUNNING_SIGNAL_TIMEOUT_MS,
+    })]
+
+    expect(advanceBackgroundTaskChips(tasks, NOW)).toBe(tasks)
+  })
+
+  it('retains and prunes terminal states using their existing linger windows', () => {
+    const completedVisible = task({ status: 'completed', completedAt: NOW - TERMINAL_LINGER_MS + 1 })
+    const completedExpired = task({ id: 'task-2', status: 'completed', completedAt: NOW - TERMINAL_LINGER_MS })
+    const orphanVisible = task({ id: 'task-3', status: 'orphaned', completedAt: NOW - ORPHANED_LINGER_MS + 1 })
+    const orphanExpired = task({ id: 'task-4', status: 'orphaned', completedAt: NOW - ORPHANED_LINGER_MS })
+
+    const next = advanceBackgroundTaskChips([
+      completedVisible,
+      completedExpired,
+      orphanVisible,
+      orphanExpired,
+    ], NOW)
+
+    expect(next.map(item => item.id)).toEqual(['task-1', 'task-3'])
+  })
+
+  it('restores a stale task to running when progress resumes', () => {
+    const stale = task({ status: 'stale', lastSignalAt: NOW - RUNNING_SIGNAL_TIMEOUT_MS })
+    const next = markBackgroundTaskSignal(stale, NOW)
+
+    expect(next.status).toBe('running')
+    expect(next.lastSignalAt).toBe(NOW)
+  })
+
+  it('does not resurrect terminal tasks on late progress', () => {
+    const completed = task({ status: 'completed', completedAt: NOW - 1 })
+
+    expect(markBackgroundTaskSignal(completed, NOW)).toBe(completed)
+  })
+
+  it('turn teardown converts both running and stale tasks to true orphaned state', () => {
+    const next = markLiveBackgroundTasksOrphaned([
+      task(),
+      task({ id: 'task-2', status: 'stale' }),
+      task({ id: 'task-3', status: 'completed', completedAt: NOW - 1 }),
+    ], NOW)
+
+    expect(next.map(item => item.status)).toEqual(['orphaned', 'orphaned', 'completed'])
+    expect(next[0]?.completedAt).toBe(NOW)
+    expect(next[1]?.completedAt).toBe(NOW)
+  })
+})

--- a/apps/electron/src/renderer/components/app-shell/background-task-chip-state.ts
+++ b/apps/electron/src/renderer/components/app-shell/background-task-chip-state.ts
@@ -1,0 +1,83 @@
+import type { BackgroundTask } from '@/atoms/sessions'
+
+/** How long real terminal/orphaned chips remain visible. */
+export const TERMINAL_LINGER_MS = 8_000
+export const ORPHANED_LINGER_MS = 20_000
+
+/**
+ * A missing lifecycle signal is not proof that a task stopped. After this long,
+ * replace the spinner with an explicit unknown/stale state while keeping the chip
+ * available for a later progress or completion event.
+ */
+export const RUNNING_SIGNAL_TIMEOUT_MS = 20 * 60_000
+
+/**
+ * Advance age-based chip state and prune only states known to be terminal.
+ * Returns the original array when nothing changed to avoid spurious Jotai renders.
+ */
+export function advanceBackgroundTaskChips(
+  tasks: BackgroundTask[],
+  now: number,
+): BackgroundTask[] {
+  let changed = false
+  const next = tasks
+    .map((task) => {
+      const lastSignalAt = task.lastSignalAt ?? task.startTime
+      if (
+        task.status === 'running'
+        && now - lastSignalAt >= RUNNING_SIGNAL_TIMEOUT_MS
+      ) {
+        changed = true
+        return { ...task, status: 'stale' as const }
+      }
+      return task
+    })
+    .filter((task) => {
+      if (task.status === 'running' || task.status === 'stale') return true
+      const age = now - (task.completedAt ?? now)
+      const linger = task.status === 'orphaned'
+        ? ORPHANED_LINGER_MS
+        : TERMINAL_LINGER_MS
+      return age < linger
+    })
+
+  if (next.length !== tasks.length) changed = true
+  return changed ? next : tasks
+}
+
+/**
+ * Record evidence that a task is still alive. A stale task can recover to running,
+ * but late progress must never resurrect a truly terminal task.
+ */
+export function markBackgroundTaskSignal(
+  task: BackgroundTask,
+  now: number,
+): BackgroundTask {
+  if (task.status !== 'running' && task.status !== 'stale') return task
+  return {
+    ...task,
+    status: 'running',
+    lastSignalAt: now,
+  }
+}
+
+/**
+ * Turn-end death is authoritative only when the backend did not keep background
+ * tasks alive. Both running and uncertain/stale chips become truly orphaned.
+ */
+export function markLiveBackgroundTasksOrphaned(
+  tasks: BackgroundTask[],
+  now: number,
+): BackgroundTask[] {
+  let changed = false
+  const next = tasks.map((task) => {
+    if (task.status !== 'running' && task.status !== 'stale') return task
+    changed = true
+    return {
+      ...task,
+      status: 'orphaned' as const,
+      completedAt: now,
+    }
+  })
+  return changed ? next : tasks
+}

--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -76,7 +76,7 @@ import { useEscapeInterrupt } from '@/context/EscapeInterruptContext'
 import { hasOpenOverlay } from '@/lib/overlay-detection'
 import { ToolbarStatusSlot } from './ToolbarStatusSlot'
 import { buildPlanApprovalMessage } from '../plan-approval-message'
-import { shouldHandleScopedInputEvent } from './input-event-guards'
+import { shouldHandleScopedInputEvent, shouldRecallPromptOnArrowUp } from './input-event-guards'
 import { clearPendingFocusForSession, consumePendingFocusForSession } from './focus-input-events'
 import {
   getRecentWorkingDirs,
@@ -1355,6 +1355,31 @@ export function FreeFormInput({
         inlineLabel.close()
         return
       }
+    }
+
+    // Plain Arrow Up with no draft content cancels the running turn and recalls
+    // its prompt through ChatDisplay.handleStop. The pure guard deliberately
+    // treats whitespace, attachments, loading files, and follow-up chips as draft
+    // content so normal editing is never hijacked.
+    if (shouldRecallPromptOnArrowUp({
+      key: e.key,
+      shiftKey: e.shiftKey,
+      metaKey: e.metaKey,
+      ctrlKey: e.ctrlKey,
+      altKey: e.altKey,
+      isComposing: e.nativeEvent.isComposing,
+      isProcessing,
+      input,
+      attachmentCount: attachments.length,
+      loadingAttachmentCount: loadingCount,
+      followUpItemCount: followUpItems.length,
+      inlineMenuOpen: inlineMention.isOpen || inlineSlash.isOpen || inlineLabel.isOpen,
+      disabled,
+      disableSend,
+    })) {
+      e.preventDefault()
+      handleStop()
+      return
     }
 
     // Skip submission during IME composition - user is confirming composed characters, not sending

--- a/apps/electron/src/renderer/components/app-shell/input/__tests__/input-event-guards.test.ts
+++ b/apps/electron/src/renderer/components/app-shell/input/__tests__/input-event-guards.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { shouldHandleScopedInputEvent } from '../input-event-guards'
+import {
+  shouldHandleScopedInputEvent,
+  shouldRecallPromptOnArrowUp,
+  type RecallPromptArrowUpState,
+} from '../input-event-guards'
 
 describe('shouldHandleScopedInputEvent', () => {
   it('handles targeted event only for matching session', () => {
@@ -26,5 +30,57 @@ describe('shouldHandleScopedInputEvent', () => {
       sessionId: 'session-a',
       isFocusedPanel: false,
     })).toBe(false)
+  })
+})
+
+const EMPTY_RECALL_STATE: RecallPromptArrowUpState = {
+  key: 'ArrowUp',
+  shiftKey: false,
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  isComposing: false,
+  isProcessing: true,
+  input: '',
+  attachmentCount: 0,
+  loadingAttachmentCount: 0,
+  followUpItemCount: 0,
+  inlineMenuOpen: false,
+  disabled: false,
+  disableSend: false,
+}
+
+function canRecall(overrides: Partial<RecallPromptArrowUpState> = {}): boolean {
+  return shouldRecallPromptOnArrowUp({ ...EMPTY_RECALL_STATE, ...overrides })
+}
+
+describe('shouldRecallPromptOnArrowUp', () => {
+  it('allows plain Arrow Up only for a truly empty draft during processing', () => {
+    expect(canRecall()).toBe(true)
+    expect(canRecall({ isProcessing: false })).toBe(false)
+    expect(canRecall({ key: 'ArrowDown' })).toBe(false)
+  })
+
+  it('preserves text and whitespace-only editing', () => {
+    expect(canRecall({ input: 'draft' })).toBe(false)
+    expect(canRecall({ input: '   ' })).toBe(false)
+    expect(canRecall({ input: '\n' })).toBe(false)
+  })
+
+  it('preserves non-text draft content and loading attachments', () => {
+    expect(canRecall({ attachmentCount: 1 })).toBe(false)
+    expect(canRecall({ loadingAttachmentCount: 1 })).toBe(false)
+    expect(canRecall({ followUpItemCount: 1 })).toBe(false)
+  })
+
+  it('does not steal keys from menus, IME, modifiers, or disabled input', () => {
+    expect(canRecall({ inlineMenuOpen: true })).toBe(false)
+    expect(canRecall({ isComposing: true })).toBe(false)
+    expect(canRecall({ shiftKey: true })).toBe(false)
+    expect(canRecall({ metaKey: true })).toBe(false)
+    expect(canRecall({ ctrlKey: true })).toBe(false)
+    expect(canRecall({ altKey: true })).toBe(false)
+    expect(canRecall({ disabled: true })).toBe(false)
+    expect(canRecall({ disableSend: true })).toBe(false)
   })
 })

--- a/apps/electron/src/renderer/components/app-shell/input/input-event-guards.ts
+++ b/apps/electron/src/renderer/components/app-shell/input/input-event-guards.ts
@@ -18,3 +18,56 @@ export function shouldHandleScopedInputEvent({
   }
   return isFocusedPanel
 }
+
+export interface RecallPromptArrowUpState {
+  key: string
+  shiftKey: boolean
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  isComposing: boolean
+  isProcessing: boolean
+  input: string
+  attachmentCount: number
+  loadingAttachmentCount: number
+  followUpItemCount: number
+  inlineMenuOpen: boolean
+  disabled: boolean
+  disableSend: boolean
+}
+
+/**
+ * Plain Arrow Up recalls/cancels only when there is truly no editable draft.
+ * Whitespace, attachments, loading files, and follow-up context are all content.
+ */
+export function shouldRecallPromptOnArrowUp({
+  key,
+  shiftKey,
+  metaKey,
+  ctrlKey,
+  altKey,
+  isComposing,
+  isProcessing,
+  input,
+  attachmentCount,
+  loadingAttachmentCount,
+  followUpItemCount,
+  inlineMenuOpen,
+  disabled,
+  disableSend,
+}: RecallPromptArrowUpState): boolean {
+  return key === 'ArrowUp'
+    && !shiftKey
+    && !metaKey
+    && !ctrlKey
+    && !altKey
+    && !isComposing
+    && isProcessing
+    && !disabled
+    && !disableSend
+    && input === ''
+    && attachmentCount === 0
+    && loadingAttachmentCount === 0
+    && followUpItemCount === 0
+    && !inlineMenuOpen
+}

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -1235,20 +1235,25 @@ export class SessionManager implements ISessionManager {
    * 2. A session-bound {@link RemoteBrowserPaneManager} when `rpcServer` is set.
    *    Cached in `remoteBpms` so repeat lookups don't allocate.
    * 3. `null` when there's neither a local BPM nor an RPC server.
+   *
+   * `opts.workspaceId` is a fallback used when the session is not yet registered
+   * in `this.sessions` (e.g. during eager agent creation for branch preflight,
+   * before the session is inserted). Without it the remote bridge could not be
+   * built and the caller's "passed the gate" invariant would be violated.
    */
-  getBrowserPaneManagerForSession(sid: string): IBrowserPaneManager | null {
+  getBrowserPaneManagerForSession(sid: string, opts?: { workspaceId?: string }): IBrowserPaneManager | null {
     if (this.browserPaneManager) return this.browserPaneManager
     if (!this.rpcServer) return null
 
     const cached = this.remoteBpms.get(sid)
     if (cached) return cached
 
-    const session = this.sessions.get(sid)
-    if (!session) return null
+    const workspaceId = this.sessions.get(sid)?.workspace.id ?? opts?.workspaceId
+    if (!workspaceId) return null
 
     const bridge = new RemoteBrowserPaneManager({
       sessionId: sid,
-      workspaceId: session.workspace.id,
+      workspaceId,
       rpcServer: this.rpcServer,
       getHostClient: () => this.getBrowserHostClient(sid),
     })
@@ -2822,6 +2827,15 @@ export class SessionManager implements ISessionManager {
       messagesLoaded: !isBranch,  // Branched sessions: lazy-load messages from JSONL
     })
 
+    // Register the session and initialize mode-manager state BEFORE any eager
+    // agent creation (branch preflight). getOrCreateAgent's browser-pane wiring
+    // resolves the session via this.sessions, so it must be present first.
+    setPermissionMode(storedSession.id, managed.permissionMode ?? 'ask', { changedBy: 'restore' })
+    if (managed.previousPermissionMode) {
+      hydratePreviousPermissionMode(storedSession.id, managed.previousPermissionMode)
+    }
+    this.sessions.set(storedSession.id, managed)
+
     // Eagerly load messages for branched sessions so the renderer gets the full
     // conversation immediately (needed for scroll-to-bottom on panel open)
     if (isBranch) {
@@ -2867,15 +2881,6 @@ export class SessionManager implements ISessionManager {
         }
       }
     }
-
-    // Initialize mode-manager state immediately to avoid UI/enforcement races
-    // before the agent instance is lazily created.
-    setPermissionMode(storedSession.id, managed.permissionMode ?? 'ask', { changedBy: 'restore' })
-    if (managed.previousPermissionMode) {
-      hydratePreviousPermissionMode(storedSession.id, managed.previousPermissionMode)
-    }
-
-    this.sessions.set(storedSession.id, managed)
 
     // Initialize session metadata in AutomationSystem for diffing
     const automationSystem = this.automationSystems.get(workspaceRootPath)
@@ -3454,7 +3459,7 @@ export class SessionManager implements ISessionManager {
       })
       if (this.browserPaneManager || this.rpcServer) {
         const sid = managed.id
-        const bpm = this.getBrowserPaneManagerForSession(sid)
+        const bpm = this.getBrowserPaneManagerForSession(sid, { workspaceId: managed.workspace.id })
         if (!bpm) {
           throw new Error('Browser pane manager unavailable despite passing the gate — this is a bug.')
         }

--- a/packages/server-core/src/sessions/__tests__/browser-pane-branch-preflight.test.ts
+++ b/packages/server-core/src/sessions/__tests__/browser-pane-branch-preflight.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test'
+import { SessionManager } from '../SessionManager.ts'
+import { RemoteBrowserPaneManager } from '../RemoteBrowserPaneManager.ts'
+
+// Regression test for:
+//   "Could not create branch: Browser pane manager unavailable despite passing
+//    the gate — this is a bug."
+//
+// On a remote/RPC deployment, the sdk-fork branch preflight calls
+// getOrCreateAgent() — which wires browser-pane tools via
+// getBrowserPaneManagerForSession() — BEFORE the session is registered in
+// this.sessions. The remote resolver used to read workspace.id off the
+// (missing) session and return null, tripping the "passed the gate" invariant.
+//
+// The resolver now accepts a workspaceId fallback so it can build the remote
+// bridge even when the session is not yet registered.
+describe('getBrowserPaneManagerForSession — branch preflight', () => {
+  it('builds a remote bridge from the workspaceId fallback when the session is not registered', () => {
+    const sm = new SessionManager()
+    sm.setRpcServer({} as never) // remote path: rpcServer present, no local BPM
+
+    const bpm = sm.getBrowserPaneManagerForSession('unregistered-session', {
+      workspaceId: 'ws_test',
+    })
+
+    expect(bpm).not.toBeNull()
+    expect(bpm).toBeInstanceOf(RemoteBrowserPaneManager)
+  })
+
+  it('returns null only when there is neither a local BPM, a session, nor a workspaceId fallback', () => {
+    const sm = new SessionManager()
+    sm.setRpcServer({} as never)
+
+    expect(sm.getBrowserPaneManagerForSession('unregistered-session')).toBeNull()
+  })
+})

--- a/packages/session-tools-core/src/handlers/list-background-tasks.ts
+++ b/packages/session-tools-core/src/handlers/list-background-tasks.ts
@@ -16,8 +16,7 @@ export interface ListBackgroundTasksArgs {
  * previous turn is invisible to them once that subprocess is torn down. This
  * tool reads the cross-subprocess registry instead, so a "status?" query returns
  * a truthful answer — including tasks that were `orphaned` when their owning turn
- * ended. Never guess or claim "the app restarted"; report exactly what the
- * registry says.
+ * ended. Report exactly what the registry says.
  */
 export async function handleListBackgroundTasks(
   ctx: SessionToolContext,

--- a/packages/session-tools-core/src/tool-defs.ts
+++ b/packages/session-tools-core/src/tool-defs.ts
@@ -382,7 +382,9 @@ Use this when a source provides HTML templates for rich rendering of its data (e
 
 Templates use Mustache syntax — the tool handles rendering and writes the output HTML to the session data folder.`,
 
-  browser_tool: `Run browser actions using a CLI-like command (string or array input).
+  browser_tool: `Read \`~/.craft-agent/docs/browser-tools.md\` before first use — the runtime blocks calls until you do.
+
+Run browser actions using a CLI-like command (string or array input).
 
 All browser interactions use this single tool with strict validation and actionable feedback.
 String mode supports batching with semicolons: \`fill @e1 value; fill @e2 value; click @e3\`
@@ -488,7 +490,7 @@ Status meanings:
 - completed / failed / stopped: a terminal notification was received.
 - orphaned: the turn that launched the task ended before it finished, so it was terminated with that turn's subprocess.
 
-Never guess or claim "the app restarted" — report exactly what this tool returns. Omit sessionId for the current session.`,
+This is the authoritative cross-turn task registry; the SDK's in-subprocess task tools cannot see tasks from a prior turn. Report exactly what this tool returns. Omit sessionId for the current session.`,
 
   send_agent_message: `Send a message to another session. The message is delivered with your session ID so the target can reply back.
 

--- a/packages/shared/src/agent/core/source-manager.ts
+++ b/packages/shared/src/agent/core/source-manager.ts
@@ -238,7 +238,7 @@ export class SourceManager {
       }
       if (hasGuides) {
         parts.push('');
-        parts.push('IMPORTANT: You MUST read a source\'s guide with the Read tool BEFORE using any of its tools. Tool calls WILL BE REJECTED if the guide has not been read first.');
+        parts.push('Read a source\'s guide before using its tools — the runtime rejects tool calls until you do.');
       }
     }
 

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -249,6 +249,7 @@
   "chat.stopTask": "Aufgabe stoppen",
   "chat.tapToType": "Tippen zum Schreiben",
   "chat.taskOrphanedHint": "This background task was terminated when its turn ended.",
+  "chat.taskStaleHint": "Es wurde keine Abschlussmeldung empfangen. Diese Aufgabe wird möglicherweise noch ausgeführt.",
   "chat.taskStatusDone": "done",
   "chat.taskStatusFailed": "failed",
   "chat.taskStatusOrphaned": "orphaned",

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -249,6 +249,7 @@
   "chat.stopTask": "Stop Task",
   "chat.tapToType": "Tap to type",
   "chat.taskOrphanedHint": "This background task was terminated when its turn ended.",
+  "chat.taskStaleHint": "No completion update was received. This task may still be running.",
   "chat.taskStatusDone": "done",
   "chat.taskStatusFailed": "failed",
   "chat.taskStatusOrphaned": "orphaned",

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -249,6 +249,7 @@
   "chat.stopTask": "Detener tarea",
   "chat.tapToType": "Toca para escribir",
   "chat.taskOrphanedHint": "This background task was terminated when its turn ended.",
+  "chat.taskStaleHint": "No se recibió ninguna actualización de finalización. Es posible que esta tarea siga ejecutándose.",
   "chat.taskStatusDone": "done",
   "chat.taskStatusFailed": "failed",
   "chat.taskStatusOrphaned": "orphaned",

--- a/packages/shared/src/i18n/locales/hu.json
+++ b/packages/shared/src/i18n/locales/hu.json
@@ -249,6 +249,7 @@
   "chat.stopTask": "Feladat leállítása",
   "chat.tapToType": "Koppintson az íráshoz",
   "chat.taskOrphanedHint": "This background task was terminated when its turn ended.",
+  "chat.taskStaleHint": "Nem érkezett befejezési frissítés. Lehet, hogy a feladat még fut.",
   "chat.taskStatusDone": "done",
   "chat.taskStatusFailed": "failed",
   "chat.taskStatusOrphaned": "orphaned",

--- a/packages/shared/src/i18n/locales/ja.json
+++ b/packages/shared/src/i18n/locales/ja.json
@@ -249,6 +249,7 @@
   "chat.stopTask": "タスクを停止",
   "chat.tapToType": "タップして入力",
   "chat.taskOrphanedHint": "This background task was terminated when its turn ended.",
+  "chat.taskStaleHint": "完了通知を受信していません。このタスクはまだ実行中の可能性があります。",
   "chat.taskStatusDone": "done",
   "chat.taskStatusFailed": "failed",
   "chat.taskStatusOrphaned": "orphaned",

--- a/packages/shared/src/i18n/locales/pl.json
+++ b/packages/shared/src/i18n/locales/pl.json
@@ -249,6 +249,7 @@
   "chat.stopTask": "Zatrzymaj zadanie",
   "chat.tapToType": "Stuknij, aby pisać",
   "chat.taskOrphanedHint": "This background task was terminated when its turn ended.",
+  "chat.taskStaleHint": "Nie otrzymano informacji o zakończeniu. To zadanie może nadal działać.",
   "chat.taskStatusDone": "done",
   "chat.taskStatusFailed": "failed",
   "chat.taskStatusOrphaned": "orphaned",

--- a/packages/shared/src/i18n/locales/zh-Hans.json
+++ b/packages/shared/src/i18n/locales/zh-Hans.json
@@ -249,6 +249,7 @@
   "chat.stopTask": "停止任务",
   "chat.tapToType": "点击输入",
   "chat.taskOrphanedHint": "This background task was terminated when its turn ended.",
+  "chat.taskStaleHint": "未收到完成更新。此任务可能仍在运行。",
   "chat.taskStatusDone": "done",
   "chat.taskStatusFailed": "failed",
   "chat.taskStatusOrphaned": "orphaned",

--- a/packages/shared/src/prompts/system.ts
+++ b/packages/shared/src/prompts/system.ts
@@ -576,8 +576,6 @@ function getCraftAssistantPrompt(workspaceRootPath?: string, backendName: string
 You can control built-in browser windows through \`browser_tool\`, a unified CLI-like interface.
 Multiple commands can be batched with semicolons (e.g., \`fill @e1 x; fill @e2 y; click @e3\`). Batches stop after navigation commands.
 
-**IMPORTANT:** All browser tool calls are **blocked** until you read \`${DOC_REFS.browserTools}\`. Always read this guide before your first browser tool call in a session.
-
 Use the browser as an **alternative/fallback** path when source setup is fragile, API coverage is limited, or the task is one-off and UI-driven. Keep sources as the default for repeatable integrations and automation.
 
 **Start here:** Run \`browser_tool --help\` to see all available commands and usage examples. Use it whenever you're unsure what's available or how to call something.
@@ -696,7 +694,7 @@ Read relevant context files using the Read tool - they contain architecture info
 | LLM Tool | \`${DOC_REFS.llmTool}\` | When using \`call_llm\` for subtasks |${FEATURE_FLAGS.craftAgentsCli ? `
 | Craft CLI | \`${DOC_REFS.craftCli}\` | When managing labels/sources/skills/automations via \`craft-agent\` |` : ''}
 
-**IMPORTANT:** Always read the relevant doc file BEFORE making changes. Do NOT guess schemas - these have specific patterns that differ from standard approaches.${FEATURE_FLAGS.craftAgentsCli ? `
+Read the relevant doc file before changing config — these schemas differ from standard patterns, so guessing fails.${FEATURE_FLAGS.craftAgentsCli ? `
 
 ## Craft Agent CLI
 
@@ -715,15 +713,13 @@ When you learn information about the user (their name, timezone, location, langu
 
 ## Interaction Guidelines
 
-1. **Be Concise**: Provide focused, actionable responses.
-2. **Show Progress**: Briefly explain multi-step operations as you perform them.
-3. **Confirm Destructive Actions**: Always ask before deleting content.
-4. **Use Available Tools**: Only call tools that exist. Check the tool list and use exact names.
-5. **Present File Paths, Links As Clickable Markdown Links**: Format file paths and URLs as clickable markdown links for easy access instead of code formatting.
-6. **Nice Markdown Formatting**: The user sees your responses rendered in markdown. Use headings, lists, bold/italic text, and code blocks for clarity. Basic HTML is also supported, but use sparingly.
-7. **Math Delimiters**: Use \`$$...$$\` for math expressions. Do NOT use single-dollar delimiters (\`$...$\`) in normal prose so currency values like \`$100\` or \`$2M–$4M\` stay plain text.
+1. **Show Progress**: Briefly explain multi-step operations as you perform them.
+2. **Confirm Destructive Actions**: Always ask before deleting content.
+3. **Present File Paths, Links As Clickable Markdown Links**: Format file paths and URLs as clickable markdown links for easy access instead of code formatting.
+4. **Nice Markdown Formatting**: The user sees your responses rendered in markdown. Use headings, lists, bold/italic text, and code blocks for clarity. Basic HTML is also supported, but use sparingly.
+5. **Math Delimiters**: Use \`$$...$$\` for math expressions. Do NOT use single-dollar delimiters (\`$...$\`) in normal prose so currency values like \`$100\` or \`$2M–$4M\` stay plain text.
 
-!!IMPORTANT!!. You must refer to yourself as Craft Agent when asked. You can acknowledge that you are powered by ${backendName}.
+Refer to yourself as Craft Agent when asked. You can acknowledge that you are powered by ${backendName}.
 
 ${includeCoAuthoredBy ? `## Git Conventions
 
@@ -747,12 +743,9 @@ Current mode is in \`<session_state>\`, along with last mode-transition metadata
 **${PERMISSION_MODE_CONFIG['safe'].displayName} mode:** Read, search, and explore freely. Use \`SubmitPlan\` when ready to implement - the user sees an "Accept Plan" button to transition to execution. 
 Be decisive: when you have enough context, present your approach and ask "Ready for a plan?" or write it directly. This will help the user move forward.
 
-!!Important!! - Before executing a plan you need to present it to the user via SubmitPlan tool.
-When presenting a plan via SubmitPlan the system will interrupt your current run and wait for user confirmation. Expect, and prepare for this.
-Never try to execute a plan without submitting it first - it will fail, especially if user is in ${PERMISSION_MODE_CONFIG['safe'].displayName} mode.
+When ready to implement, call SubmitPlan. It interrupts the turn and waits for the user to accept before execution begins — so submit the plan before acting on it.
 
-**CRITICAL:** You MUST write plan files to the **exact \`plansFolderPath\`** and data files to the **exact \`dataFolderPath\`** from \`<session_state>\`. These folders already exist (created by the system). Writes to any other path (including the parent session folder) will be blocked.
-**Do NOT** write to \`.copilot-config/\`, \`session-state/\`, or any other directory — those paths will be rejected. Use ONLY \`plansFolderPath\` or \`dataFolderPath\`.
+Write plan files to the exact \`plansFolderPath\` and data files to the exact \`dataFolderPath\` from \`<session_state>\`. The runtime blocks writes elsewhere.
 ${backendName === 'Codex' ? `
 ### Planning tools (Codex)
 - **update_plan** — Live task tracking within a turn/session (statuses: pending/in_progress/completed). Does not pause execution or request approval.
@@ -831,7 +824,7 @@ The \`session\` MCP server provides tools for managing external sources:
 
 You have access to web search for up-to-date information. Use it proactively to get up-to-date information and best practices.
 Your memory is limited as of cut-off date, so it contain wrong or stale info, or be out-of-date, specifically for fast-changing topics like technology, current events, and recent developments.
-I.e. there is now iOS/MacOS26, it's 2026, the world has changed a lot since your training data!
+I.e. there is now iOS/MacOS26, it's 2026, the world has changed since your training data — prefer web search for current facts.
 
 ## Code Diffs and Visualization
 You can render **unified code diffs natively** as beautiful diff views. Use diffs where it makes sense to show changes. Users will love it.
@@ -913,16 +906,6 @@ The file should contain \`{"rows": [...]}\` or just a rows array \`[...]\`. Inli
 - Runs in isolated subprocess (no API keys, 30s timeout)
 - Available in all permission modes including Explore
 
-**Example:**
-\`\`\`
-transform_data({
-  language: "python3",
-  script: "import json, sys\\ndata = json.load(open(sys.argv[1]))\\nrows = [{\\"id\\": t[\\"id\\"], \\"amount\\": t[\\"amount\\"]} for t in data[\\"transactions\\"]]\\njson.dump({\\"rows\\": rows}, open(sys.argv[2], \\"w\\"))\\n",
-  inputFiles: ["long_responses/stripe_result.txt"],
-  outputFile: "transactions.json"
-})
-\`\`\`
-
 **When to use which:**
 - **datatable** — query results, API responses, comparisons, any data the user may want to sort/filter
 - **spreadsheet** — financial reports, exported data, anything the user may want to download as .xlsx
@@ -979,7 +962,7 @@ If you get a "Labels rejected" error, the reason is per-entry — common causes 
 - Do NOT call \`list_sessions\` with a high limit just to scan all sessions — filter first.
 
 **Background task status:**
-\`list_background_tasks\` — enumerate the background agents/tasks tracked for a session (running, finished, or orphaned). This is the ONLY reliable way to answer "what is running / what's the status?" — it reads the main-process registry, which tracks tasks across turns. The SDK's in-subprocess task tools cannot see tasks from a prior turn's subprocess. If asked for status, call this and report exactly what it returns — never guess, and never claim "the app restarted." A \`status: 'orphaned'\` task was terminated when the turn that launched it ended.
+\`list_background_tasks\` — enumerate the background agents/tasks tracked for a session (running, finished, or orphaned). This is the ONLY reliable way to answer "what is running / what's the status?" — it reads the main-process registry, which tracks tasks across turns. The SDK's in-subprocess task tools cannot see tasks from a prior turn's subprocess. If asked for status, call this and report exactly what it returns. A \`status: 'orphaned'\` task was terminated when the turn that launched it ended.
 
 **Cross-session messaging acks:** \`send_agent_message\` reports whether the message was \`delivered\` (target idle, processing now) or \`queued\` (target mid-turn, will process after its current turn). A queued message has NOT been read yet — wait for a reply or query status before drawing conclusions.
 
@@ -1043,16 +1026,6 @@ You can render \`html-preview\` code blocks as live HTML previews in sandboxed i
 - **HTML reports** or styled documents from APIs
 - **Rich content** where markdown conversion would lose formatting/layout
 - Any content with complex CSS, tables, or images that should render as-is
-
-**Example with transform_data (for base64 email body):**
-\`\`\`
-transform_data({
-  language: "python3",
-  script: "import base64, sys, json\\ndata = json.load(open(sys.argv[1]))\\nhtml = base64.urlsafe_b64decode(data['payload']['parts'][1]['body']['data']).decode('utf-8')\\nopen(sys.argv[2], 'w').write(html)",
-  inputFiles: ["long_responses/gmail_message.txt"],
-  outputFile: "email.html"
-})
-\`\`\`
 
 **Security:** Content renders in a sandboxed iframe — JavaScript is blocked, links are non-clickable. No sanitization needed.
 


### PR DESCRIPTION
The fix is committed + pushed: branch integration/cmdk-and-branch-fix (commit b7a48530) on github.com/kiancjy/craft-agents-oss. This branch also carries the palette itself and other 0.11.x backports.

=== 1. Update the build checkout ===
# If ~/craft-agents-oss-build exists from last time:
cd ~/craft-agents-oss-build
git fetch fork || git fetch origin
git checkout integration/cmdk-and-branch-fix
git pull
# If it does NOT exist, clone fresh:
#   git clone https://github.com/kiancjy/craft-agents-oss ~/craft-agents-oss-build
#   cd ~/craft-agents-oss-build && git checkout integration/cmdk-and-branch-fix

=== 2. Build ===
bun install
bun run electron:dist:mac        # -> apps/electron/release/Craft-Agents-arm64.dmg (few min)
ls -lh apps/electron/release/Craft-Agents-arm64.dmg   # confirm it built

=== 3. Install (back up first) ===
sudo cp -R "/Applications/Craft Agents.app" "/Applications/Craft Agents.prev.app.bak"
osascript -e 'quit app "Craft Agents"' 2>/dev/null; sleep 2
hdiutil attach apps/electron/release/Craft-Agents-arm64.dmg
rm -rf "/Applications/Craft Agents.app"
cp -R "/Volumes/Craft Agents/Craft Agents.app" /Applications/
hdiutil detach "/Volumes/Craft Agents"
xattr -dr com.apple.quarantine "/Applications/Craft Agents.app"   # unsigned build

=== 4. Launch + verify ===
ssh -L 9100:localhost:9100 kian@devbox-kian.tail170a7f.ts.net -fN 2>/dev/null   # backend tunnel
open -a "Craft Agents"
# In the app: ⌘K -> Model group should now include "Opus 5". Selecting it sets the session model.

=== Rollback if needed ===
osascript -e 'quit app "Craft Agents"'; sleep 2
rm -rf "/Applications/Craft Agents.app"
mv "/Applications/Craft Agents.prev.app.bak" "/Applications/Craft Agents.app"
xattr -dr com.apple.quarantine "/Applications/Craft Agents.app"; open -a "Craft Agents"

Notes:
- Full detail: /home/kian/.craft-agent/workspaces/work/sessions/260722-fine-panther/plans/mac-build-install-runbook.md on the box (read via SSH).
- Prereqs if missing: bun, and Xcode CLT (xcode-select --install).
- The box server does NOT need touching for this — it's a renderer-only change; only the Mac app must be rebuilt.